### PR TITLE
Disable vote event postimport to avoid lots of vote event deletions

### DIFF
--- a/app.py
+++ b/app.py
@@ -13,7 +13,6 @@ logging.getLogger("boto3").setLevel(logging.WARNING)
 logging.getLogger("s3transfer").setLevel(logging.WARNING)
 logging.getLogger("urllib3.connectionpool").setLevel(logging.WARNING)
 
-
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
@@ -289,8 +288,11 @@ def do_import(jurisdiction_id: str, datadir: str) -> None:
     # datadir = os.path.join(settings.SCRAPED_DATA_DIR, state)
 
     juris_importer = JurisdictionImporter(jurisdiction_id)
+    # bills postimport disabled because bill postimport does some expensive SQL, and we want this to be fast
     bill_importer = BillImporter(jurisdiction_id, do_postimport=False)
-    vote_event_importer = VoteEventImporter(jurisdiction_id, bill_importer)
+    # votes postimport disabled because it will delete all vote events for the related bill
+    # except the vote event being processed now, causing votes to be deleted and re-created
+    vote_event_importer = VoteEventImporter(jurisdiction_id, bill_importer, do_postimport=False)
     event_importer = EventImporter(jurisdiction_id, vote_event_importer)
     logger.info(f"Datadir: {datadir}")
 

--- a/app.py
+++ b/app.py
@@ -288,11 +288,15 @@ def do_import(jurisdiction_id: str, datadir: str) -> None:
     # datadir = os.path.join(settings.SCRAPED_DATA_DIR, state)
 
     juris_importer = JurisdictionImporter(jurisdiction_id)
-    # bills postimport disabled because bill postimport does some expensive SQL, and we want this to be fast
+    # bills postimport disabled because bill postimport does some expensive SQL
+    # that we want this to be fast
     bill_importer = BillImporter(jurisdiction_id, do_postimport=False)
-    # votes postimport disabled because it will delete all vote events for the related bill
-    # except the vote event being processed now, causing votes to be deleted and re-created
-    vote_event_importer = VoteEventImporter(jurisdiction_id, bill_importer, do_postimport=False)
+    # votes postimport disabled because it will delete all vote events for the
+    # related bill except the vote event being processed now, causing votes to
+    # be deleted and re-created
+    vote_event_importer = VoteEventImporter(
+        jurisdiction_id, bill_importer, do_postimport=False
+    )
     event_importer = EventImporter(jurisdiction_id, vote_event_importer)
     logger.info(f"Datadir: {datadir}")
 


### PR DESCRIPTION
I believe we are causing vote events to be "churned" via allowing the `postimport()` logic to take place on vote events imported via this realtime lambda. Vote events `postimport()` hook basically does the function of "remove dangling vote events" (eg votes that no longer show up in the scrape). But this works by deleting all non-processed vote events associated with the related Bill, which becomes problematic when you are often not processing all the vote events related to the bill in a given execution of the lambda.

Instead, we should run a periodic full votes scrape to clean up the dangling vote events.

cc @NewAgeAirbender 